### PR TITLE
Rework example.c to fit with current non-blocking implementation.

### DIFF
--- a/example.c
+++ b/example.c
@@ -27,8 +27,8 @@ void linenoise_completion(const char *buf, linenoiseCompletions *lc) {
  */
 
 const char *world[] = { "World", "- Displays a traditional greeting"};
-const char *quit[] = { "/Quit", "- Exits this example"};
-const char *count[] = { "/Count", "- Prints the background counter"};
+const char *quit[] = { "/quit", "- Exits this example"};
+const char *count[] = { "/count", "- Prints the background counter"};
 
 const char **linenoise_hints(const char *buf) {
     if (!strcasecmp(buf,"hello")) {
@@ -108,29 +108,32 @@ int main(int argc, char **argv) {
      int ret = 0;
      int something_else = 0;
      do {
-        ret = linenoiseEdit(line, sizeof(line),"hello> ");
-        /* ret is the number of characters returned,
-         * -1 that the line was incomplete, -2 for Ctrl-D was pressed.
-         * Do something with the returned string if valid. */
-        if (ret > 0) {
-            if (line[0] != '\0' && line[0] != '/') {
-                printf("\r\necho: '%s'\r\n", line);
-                linenoiseHistoryAdd(line); /* Add to the history. */
-                linenoiseHistorySave("history.txt"); /* Save the history on disk. */
-            } else if (!strncmp(line,"/historylen",11)) {
-                /* The "/historylen" command will change the history len. */
-                int len = atoi(line+11);
-                linenoiseHistorySetMaxLen(len);
-            } else if (!strncmp(line,"/count",6)) {
-                /* Print the counter that's our background work to do */
-                printf("\r\nCounter: %d\r\n", something_else);
-            } else if (!strncmp(line,"/quit",5)) {
-                printf("\r\nQuit command received. Exiting now.\r\n");
-                ret = -2;
-            } else if (line[0] == '/') {
-                printf("\r\nUnreconized command: %s\r\n", line);
-            }
+        ret = linenoiseEdit(line, sizeof(line), "hello> ");
+        /* ret is the number of characters returned */
+        if (ret <= 0) {
+            /* Nothing to do:
+             *  0: empty command entered
+             * -1: no command to return (still collecting characters)
+             * -2: Ctrl-D was pressed so we'll quit (below)
+             */
+        } else if (line[0] != '\0' && line[0] != '/') {
+            printf("\r\necho: '%s'\r\n", line);
+            linenoiseHistoryAdd(line); /* Add to the history. */
+            linenoiseHistorySave("history.txt"); /* Save the history on disk. */
+        } else if (!strncmp(line,"/historylen",11)) {
+            /* The "/historylen" command will change the history len. */
+            int len = atoi(line+11);
+            linenoiseHistorySetMaxLen(len);
+        } else if (!strncmp(line,"/count",6)) {
+            /* Print the counter that's our background work to do */
+            printf("\r\nCounter: %d\r\n", something_else);
+        } else if (!strncmp(line,"/quit",5)) {
+            printf("\r\nQuit command received. Exiting now.\r\n");
+            ret = -2;
+        } else if (line[0] == '/') {
+            printf("\r\nUnreconized command: %s\r\n", line);
         }
+    }
         /* Do some other work in the meantime, to show that linenoiseEdit doesn't block
          * (although your implementation of linenoise_getch() might, as above)
          */

--- a/example.c
+++ b/example.c
@@ -133,7 +133,6 @@ int main(int argc, char **argv) {
         } else if (line[0] == '/') {
             printf("\r\nUnreconized command: %s\r\n", line);
         }
-    }
         /* Do some other work in the meantime, to show that linenoiseEdit doesn't block
          * (although your implementation of linenoise_getch() might, as above)
          */

--- a/example.c
+++ b/example.c
@@ -3,72 +3,139 @@
 #include <string.h>
 #include "linenoise.h"
 
+/* Functions your implementation needs to provide */
 
-void completion(const char *buf, linenoiseCompletions *lc) {
+/* linenoise_completion: Optional
+ * Provide completions to expand when Tab is pressed
+ */
+
+void linenoise_completion(const char *buf, linenoiseCompletions *lc) {
     if (buf[0] == 'h') {
         linenoiseAddCompletion(lc,"hello");
         linenoiseAddCompletion(lc,"hello there");
     }
+    if (!strcasecmp(buf, "/q")) {
+        linenoiseAddCompletion(lc,"/quit");
+    }
+    if (!strcasecmp(buf, "/c")) {
+        linenoiseAddCompletion(lc,"/count");
+    }
 }
 
-char *hints(const char *buf, int *color, int *bold) {
+/* linenoise_hints: Optional
+ * Provide hints to pop up as you type
+ */
+
+const char *world[] = { "World", "- Displays a traditional greeting"};
+const char *quit[] = { "/Quit", "- Exits this example"};
+const char *count[] = { "/Count", "- Prints the background counter"};
+
+const char **linenoise_hints(const char *buf) {
     if (!strcasecmp(buf,"hello")) {
-        *color = 35;
-        *bold = 0;
-        return " World";
+        return world;
+    }
+    if (!strcasecmp(buf,"/q")) {
+        return quit;
+    }
+    if (!strcasecmp(buf,"/c")) {
+        return count;
     }
     return NULL;
 }
 
-int main(int argc, char **argv) {
-    char *line;
-    char *prgname = argv[0];
+/* linenoise_getch: Required
+ * Returns a character from the keyboard device if one is available,
+ * otherwise -1 if nothing has been entered
+ */
 
-    /* Parse options, with --multiline we enable multi line editing. */
+int linenoise_getch(void) {
+    static int i=0;
+
+    /* Linux doesn't have a nonblocking keyboard scan function like kbhit()
+     * so simulate that by returning no character 99 times out of 100 and
+     * blocking for the 100th.  This means the main loop counter should be
+     * 100 times the number of keys pressed */
+    i++;
+    if (i % 100==0) {
+      i=0;
+      return getchar();
+    } else {
+      return -1;
+    }
+}
+
+/* linenoise_write: Required
+ * User-provided console write() function, bounded by length
+ */
+void linenoise_write(const char *buf, size_t n) {
+    printf("%.*s", (int) n, buf);
+}
+
+
+
+int main(int argc, char **argv) {
+    char *prgname = argv[0];
+    char line[1024];
+
+    /* Parse options */
     while(argc > 1) {
         argc--;
         argv++;
-        if (!strcmp(*argv,"--multiline")) {
-            linenoiseSetMultiLine(1);
-            printf("Multi-line mode enabled.\n");
-        } else if (!strcmp(*argv,"--keycodes")) {
+        if (!strcmp(*argv,"--keycodes")) {
             linenoisePrintKeyCodes();
             exit(0);
         } else {
-            fprintf(stderr, "Usage: %s [--multiline] [--keycodes]\n", prgname);
+            fprintf(stderr, "Usage: %s [--keycodes]\n", prgname);
             exit(1);
         }
     }
 
-    /* Set the completion callback. This will be called every time the
-     * user uses the <tab> key. */
-    linenoiseSetCompletionCallback(completion);
-    linenoiseSetHintsCallback(hints);
+    printf("Press Ctrl-D or type '/quit' to quit\r\n");
+    printf("Unix users: Make sure terminal is in raw mode: eg 'stty raw -echo'\r\n");
+    printf("When you have quit, blind-type 'reset' to reset your terminal\r\n");
 
     /* Load history from file. The history file is just a plain text file
      * where entries are separated by newlines. */
-    linenoiseHistoryLoad("history.txt"); /* Load the history at startup */
+    linenoiseHistoryLoad("history.txt");
+    /* If we don't have history.txt, need at least one existing history
+    entry to set up the buffer correctly */
+    linenoiseHistoryAdd("previously-entered");
 
     /* Now this is the main loop of the typical linenoise-based application.
-     * The call to linenoise() will block as long as the user types something
-     * and presses enter.
-     *
-     * The typed string is returned as a malloc() allocated string by
-     * linenoise, so the user needs to free() it. */
-    while((line = linenoise("hello> ")) != NULL) {
-        /* Do something with the string. */
-        if (line[0] != '\0' && line[0] != '/') {
-            printf("echo: '%s'\n", line);
-            linenoiseHistoryAdd(line); /* Add to the history. */
-            linenoiseHistorySave("history.txt"); /* Save the history on disk. */
-        } else if (!strncmp(line,"/historylen",11)) {
-            /* The "/historylen" command will change the history len. */
-            int len = atoi(line+11);
-            linenoiseHistorySetMaxLen(len);
-        } else if (line[0] == '/') {
-            printf("Unreconized command: %s\n", line);
+     * linenoiseEdit won't block to allow other work to continue if no keys are pressed
+     */
+
+     int ret = 0;
+     int something_else = 0;
+     do {
+        ret = linenoiseEdit(line, sizeof(line),"hello> ");
+        /* ret is the number of characters returned,
+         * -1 that the line was incomplete, -2 for Ctrl-D was pressed.
+         * Do something with the returned string if valid. */
+        if (ret > 0) {
+            if (line[0] != '\0' && line[0] != '/') {
+                printf("\r\necho: '%s'\r\n", line);
+                linenoiseHistoryAdd(line); /* Add to the history. */
+                linenoiseHistorySave("history.txt"); /* Save the history on disk. */
+            } else if (!strncmp(line,"/historylen",11)) {
+                /* The "/historylen" command will change the history len. */
+                int len = atoi(line+11);
+                linenoiseHistorySetMaxLen(len);
+            } else if (!strncmp(line,"/count",6)) {
+                /* Print the counter that's our background work to do */
+                printf("\r\nCounter: %d\r\n", something_else);
+            } else if (!strncmp(line,"/quit",5)) {
+                printf("\r\nQuit command received. Exiting now.\r\n");
+                ret = -2;
+            } else if (line[0] == '/') {
+                printf("\r\nUnreconized command: %s\r\n", line);
+            }
         }
-        free(line);
-    }
+        /* Do some other work in the meantime, to show that linenoiseEdit doesn't block
+         * (although your implementation of linenoise_getch() might, as above)
+         */
+        something_else++;
+    } while (ret != -2);
+
     return 0;
 }

--- a/linenoise.c
+++ b/linenoise.c
@@ -305,6 +305,12 @@ static ssize_t getCursorPosition(struct linenoiseState *ls)
 static int getColumns(struct linenoiseState *ls)
 {
     ssize_t result;
+
+    // atm26 XXX: disable for now:
+    // detection doesn't work and enablement
+    // causes capability exception
+    goto failed;
+
     switch (ls->mode) {
     case ln_init:
     case ln_read_regular:

--- a/linenoise.c
+++ b/linenoise.c
@@ -1026,7 +1026,7 @@ static int lnHandleCharacter(struct linenoiseState *l, char c)
         } else {
             history_len--;
             free(history[history_len]);
-            return -1;
+            return -2;
         }
         break;
     case CTRL_T:    /* ctrl-t, swaps current character with previous. */

--- a/module.conf
+++ b/module.conf
@@ -1,0 +1,1 @@
+objects linenoise.o;


### PR DESCRIPTION
Also add return code -2 when Ctrl-D is pressed.
(avoids crash due to out of bounds free in history processing)

I've removed the multiline flag, since that doesn't seem to work - not sure if it's supposed to?